### PR TITLE
add bitplane

### DIFF
--- a/bash scripts/bitplane.sh
+++ b/bash scripts/bitplane.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Manipulate Y, U, and V bitplanes to make colorful creations
+
+# Parameters:
+# $1: Input File
+# $2: Y bitplane
+# $3: U bitplane
+# $4: V bitplane
+
+low=1
+high=8
+rand1=$((low + RANDOM%(1+high-low)))
+rand2=$((low + RANDOM%(1+high-low)))
+rand3=$((low + RANDOM%(1+high-low)))
+
+Y="${2:-$rand1}"    # random default value bet 1-8
+U="${3:-$rand2}"    # random default value bet 1-8
+V="${4:-$rand3}"    # random default value bet 1-8
+
+vf=$vf"format=yuv420p10le|yuv422p10le|yuv444p10le|yuv440p10le,lutyuv=y=if(eq($Y\,-1)\,512\,if(eq($Y\,0)\,val\,bitand(val\,pow(2\,10-$Y))*pow(2\,$Y))):u=if(eq($U\,-1)\,512\,if(eq($U\,0)\,val\,bitand(val\,pow(2\,10-$U))*pow(2\,$U))):v=if(eq($V\,-1)\,512\,if(eq($V\,0)\,val\,bitand(val\,pow(2\,10-$V))*pow(2\,$V))),format=yuv444p"
+
+#printf "\n\n*******START FFMPEG COMMANDS*******\n" >&2
+#echo ffmpeg -i "'$1'" -c:v libx264 -filter_complex $vf "'${1}_bitplane.mp4'"
+#printf "********END FFMPEG COMMANDS********\n\n " >&2
+
+#ffmpeg -hide_banner -i "$1" -c:v libx264 -vf $vf "${1}_bitplane.mp4"
+
+printf "\n\n*******START FFPLAY COMMANDS*******\n" >&2
+echo ffplay "$1" -vf $vf
+printf "********END FFPLAY COMMANDS********\n\n " >&2
+
+ffplay "$1" -vf $vf


### PR DESCRIPTION
Hi,

I started work on a bitplane script; it's super hacky but it does seem to work. Sending in a PR now, as I could use some help with the bash and misc other weird things that I'm struggling with. It's very much a WIP, but right now it's hard-coded for FFplay (wanted to demo this for you) and it takes Y, U, and V arguments (tho if none are provided, it chooses random numbers bet 1-8, which I think is kinda fun). 

Few notes:
1) I really like the START FFMPEG/END FFMPEG COMMANDS echo statements that you used in one script. I think we should make this consistent across the full set of scripts, as I personally love to see how to do these things outside of the ready made code.
2) Something about the lutyuv filter seems to require a 10-bit input or something. When using the Cat video as an input, and saving to a Prores file, I was getting this error:
`
[prores @ 0x7fd4f08be800] encoding with ProRes Proxy/LT/422/422 HQ (apco, apcs, apcn, ap4h) profile, need YUV422P10 input
`
3) I think we should be able to use GETOPTS to allow users to toggle between FFmpeg and FFplay, but I haven't had a chance to play around with this, and GETOPTS is fairly confusing to me.
4) From a readability perspective, I'd love to cut this long long filter chain onto multiple lines, but everything I tried seemed to mess up FFmpeg.